### PR TITLE
channel room is now able to set to invite only

### DIFF
--- a/include/channel.hpp
+++ b/include/channel.hpp
@@ -55,7 +55,7 @@ class Channel
 
 		//for mode -marcus-:
 		void	SetInviteOnly(bool enable_invite);
-		bool	getchannelIsInviteOnly();
+		bool	getchannelIsInviteOnly() const;
 			// Invite list methods
 			void	inviteClient(int clientFd);
 			bool	getisClientInvited(int clientFd) const;

--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -28,6 +28,8 @@ std::string ERR_NOSUCHCHANNEL(const std::string &serverName, const std::string &
 std::string ERR_CANNOTSENDTOCHAN(const std::string &serverName, const std::string &clientNick, const std::string &channelName);
 // 442
 std::string ERR_NOTONCHANNEL(const std::string &serverName, const std::string &clientNick, const std::string &channelName);
+// 473
+std::string ERR_INVITEONLYCHAN(const std::string &serverName, const std::string &clientNick, const std::string &channelName);
 // 475
 std::string ERR_BADCHANNELKEY(const std::string &serverName, const std::string &clientNick, const std::string &channelName);
 // 482

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -161,14 +161,14 @@ void Channel::SetInviteOnly(bool enable_invite)
 		if (this->_inviteList.empty())
 		{
 			std::cout << GREEN << "[SUCCESS] List is cleared!" << RT << std::endl;
-			return ;
 		}
-		std::cout << RED << "[DEBUG] Failed to clear list? WHY?" << RT << std::endl;
+		else
+			std::cout << RED << "[DEBUG] Failed to clear list? WHY?" << RT << std::endl;
 	}
 	this->_inviteOnly = enable_invite;
 }
 
-bool	Channel::getchannelIsInviteOnly()
+bool	Channel::getchannelIsInviteOnly() const
 {
 	return (this->_inviteOnly);
 }
@@ -184,7 +184,7 @@ bool	Channel::getisClientInvited(int clientFd) const
 	return (std::find(_inviteList.begin(), _inviteList.end(), clientFd) != _inviteList.end());
 }
 
-//once you joined after invite you can't join back unless invited again
+// once you joined after invite you can't join back unless invited again
 void	Channel::removeInvite(int clientFd)
 {
 	std::vector<int>::iterator it = std::find(_inviteList.begin(), _inviteList.end(), clientFd);

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -50,11 +50,19 @@ std::string ERR_NOTONCHANNEL(const std::string &serverName, const std::string &c
 }
 
 
+// 473
+std::string ERR_INVITEONLYCHAN(const std::string &serverName, const std::string &clientNick, const std::string &channelName)
+{
+	return (":" + serverName + " 473 " + clientNick + " " + channelName + " :Cannot join channel (+i)" + CRLF);
+}
+
+
 // 475
 std::string ERR_BADCHANNELKEY(const std::string &serverName, const std::string &clientNick, const std::string &channelName)
 {
 	return (":" + serverName + " 475 " + clientNick + " " + channelName + " :Cannot join channel (+k) - bad key" + CRLF);
 }
+
 
 // 482
 std::string ERR_CHANOPRIVSNEEDED(const std::string &serverName, const std::string &clientNick, const std::string &channelName)

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -181,6 +181,18 @@ void Server::handleJoin(int fd, std::list<std::string> cmd_list)
 		// need to check if client is already a member
 		if (!channel->isMember(client))
 		{
+			// check if the person channel is invite only and if the person is in _invitelist
+			if (channel->getchannelIsInviteOnly() == true)
+			{
+				std::cout << RED << "[DEBUG] I am channel is invite only!" << RT << std::endl;
+				if (channel->getisClientInvited(fd) == false)
+				{
+					std::cout << RED << "Error: " << userNick 
+						<< " tried to join but was not invited" << RT << std::endl;
+					sendError(fd, ERR_INVITEONLYCHAN(serverName, userNick, channelName));
+					return ;
+				}
+			}
 			// check if there is password and if the password provided is the same
 			if (channel->hasPassword() && channel->getPassword() != password)
 			{
@@ -309,10 +321,15 @@ void	Server::handleMode(int fd, std::list<std::string> cmd_lst)
 			// [l] Set/remove the user limit to channel
 		}
 	}
-	//std::string chain = mode_chain.str();
-	//if (chain.empty())
-	//	return;
+	std::string chain = mode_chain.str();
+	if (chain.empty())
+		return;
+
  	//targetChannel->sendTo_all(RPL_CHANGEMODE(cli->getHostname(), channel->GetName(), mode_chain.str(), arguments));
+	if (targetChannel->getchannelIsInviteOnly() == true)
+		std::cout << GREEN << "[DEBUG] Channel is invite only now." << RT << std::endl;
+	std::cout << YELLOW << "[DEBUG] Current value of channel-> \"" << RED 
+		<< targetChannel->getchannelIsInviteOnly() << RT << "\"" << std::endl;
 	std::cout << GREEN << "[DEBUG] FINISH!!! WELL DONE" << RT << std::endl;
 }
 


### PR DESCRIPTION
Updated the code so that those working on the invite function would have a clear idea how to get started.

At this point the call:
"/mode #channel +i" or '-i' should set the room as invite only or undo the invite only channel status.

When people invited others to the invite only channel, their _inviteList names gets cleared and are required to be invited again.

I edited the handleJoin function a bit by ADDING things inside. I didn't change anything else.